### PR TITLE
Refresh dropdown after saving conversation

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,6 +137,7 @@ if __name__ == '__main__':
                 user_input.submit(handle_user_input, inputs=[user_input, model_choice], outputs=chatbot)
                 clear_button.click(clear_conversation, None, chatbot)
                 save_button.click(lambda: save_conversation(), None, chatbot)
+                save_button.click(lambda: gr.update(choices=get_saved_conversations()), None, load_dropdown)  # Refresh dropdown choices
                 load_button.click(load_conversation, inputs=[load_dropdown], outputs=chatbot)
                 load_button.click(lambda: gr.update(choices=get_saved_conversations()), None, load_dropdown)  # Update dropdown choices
 

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import types
+import tempfile
+import unittest
+
+# Provide stub modules for missing dependencies so ``import app`` succeeds even
+# without the real packages installed.
+sys.modules.setdefault('gradio', types.ModuleType('gradio'))
+lc_stub = types.ModuleType('langchain_openai')
+lc_stub.AzureChatOpenAI = object
+sys.modules.setdefault('langchain_openai', lc_stub)
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+import app
+
+class SaveLoadTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+        app.conversation_history = [("User", "Hello"), ("AI", "Hi")]
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        self.tmpdir.cleanup()
+
+    def test_saved_file_appears_in_list(self):
+        filename = 'test_chat.json'
+        app.save_conversation(filename)
+        self.assertIn(filename, app.get_saved_conversations())
+        loaded = app.load_conversation(filename)
+        self.assertEqual(loaded, app.conversation_history)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure the conversation picker updates when a new chat is saved
- add regression test for save/load workflow

## Testing
- `python -m py_compile app.py`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_b_687895d705f08321b69a3dfb96db6b2a